### PR TITLE
updated registration link and CENTRA 3 mtg title

### DIFF
--- a/_posts/pragma34/2017-12-15-pragma34-registration.md
+++ b/_posts/pragma34/2017-12-15-pragma34-registration.md
@@ -7,9 +7,9 @@ short: registration
 ---
 
 ## PRAGMA 34 Registration
-To register for PRAGMA / CENTRA Japan Meetings 2018, please go to the [registration page](https://acislab.wufoo.com/forms/pragmacentra-japan-meeting-2018-copy/).<br>
+To register for PRAGMA / CENTRA Japan Meetings 2018, please go to the [registration page](https://acislab.wufoo.com/forms/pragmacentra-japan-meetings-2018/).<br>
 
-Please note that PRAGMA 34 Workshop and CENTRA 3 All-Hands Meeting are held at different locations. PRAGMA 34 will be held at Akihabara Convention Hall near JR Akihabara Station and CENTRA 3 All-Hands Meeting will be held at AP Tokyo Marunouchi near JR Tokyo Station. It takes about 4 minutes from JR Akihabara Station to JR Tokyo Station on the JR Yamanote Line.<br>
+Please note that PRAGMA 34 Workshop and CENTRA 3 Meeting: Smart Cyberinfrastructure for Transnational Science are held at different locations. PRAGMA 34 will be held at Akihabara Convention Hall near JR Akihabara Station and CENTRA 3 Meeting will be held at AP Tokyo Marunouchi near JR Tokyo Station. It takes about 4 minutes from JR Akihabara Station to JR Tokyo Station on the JR Yamanote Line.<br>
 
 ### PRAGMA 34 (Akihabara, Tokyo)<br>
 May 9: Pre-workshop (ABCI visit) and Welcome Reception<br>
@@ -19,8 +19,8 @@ May 13: BoF Future of AI in Long-Tail Science<br>
 <br>
 
 ### CENTRA 3: Smart Cyberinfrastructure for Transnational Science (Marunouchi district, Tokyo)<br>
-May 14-15: CENTRA 3 All-Hands Meeting (Welcome Reception on May 14)<br>
-May 16: CENTRA 3 Post-Workshop ABCI (AIST) visit (Kashiwanoha, Kashiwa-shi)<br>
+May 14-15: [CENTRA 3 Meeting](http://www.globalcentra.org/centra3/) (Welcome Reception on May 14)<br>
+May 16: [CENTRA 3 Post-Workshop ABCI (AIST) visit](http://www.globalcentra.org/centra3/abci.html) (Kashiwanoha, Kashiwa-shi)<br>
 <br>
 
 ### ASEAN IVO Software Defined System on Disaster Mitigation and Smart Cities Meeting<br>


### PR DESCRIPTION
Nadya - I set up the PRAGMA / CENTRA 2018 Meetings registration for for the events in May and admin the globalcentra.org/centra3 content. Proposed change is for consistency when CENTRA 3 Meeting is mentioned - with 'Smart Cyberinfrastructure for Transnational Science' and removed 'All-Hands'. Shoot me an email if any question/concern or a quick Skype call is more effective. Thank you. -Grace